### PR TITLE
Optional meta and description fields at registry and record levels

### DIFF
--- a/docs/publishing-dedi-files.md
+++ b/docs/publishing-dedi-files.md
@@ -136,7 +136,8 @@ or — for a small registry — embedded verbatim in the manifest's `files[]` (s
     "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/public_key.json",
     "state": "live",                          // live | inactive
     "updated_at": "2026-07-08T10:00:00Z",     // content last changed, not merely re-issued
-    "meta": { "display_name": "Example Org signing keys" }  // optional free-form metadata
+    "description": "Current signing keys for example.org services",  // optional
+    "meta": { "display_name": "Example Org signing keys" }           // optional free-form metadata
   },
 
   "records": [                                // pure list entries — a name + schema-conformant data
@@ -175,11 +176,13 @@ or — for a small registry — embedded verbatim in the manifest's `files[]` (s
   A DeDi server MUST expose an ingested record at exactly that triple, regardless of which file, host,
   or manifest it was crawled from.
 - **`schema`** is a URL or an inline JSON Schema object, never anchored to a central host.
-- **`meta` is optional and free-form** — an object at the registry level and per record
-  (`records[].meta`), for auxiliary content such as display names, contacts, or references; it
-  mirrors the `meta` field of the DeDi API. It is signed with the rest of the file but carries no
-  verification semantics, and it is not a place for lifecycle or trust data: lifecycle stays at the
-  registry level, and keys and validity stay in the manifest and negative registries.
+- **`description` and `meta` are optional** — available at the registry level and per record.
+  `description` is a human-readable string; `meta` is a free-form object for auxiliary content such
+  as display names, contacts, or references. Both mirror the DeDi API's fields of the same names, so
+  records round-trip between the API and files without loss. They are signed with the rest of the
+  file but carry no verification semantics, and neither is a place for lifecycle or trust data:
+  lifecycle stays at the registry level, and keys and validity stay in the manifest and negative
+  registries.
 - One file = one registry. Splitting a very large registry across multiple files (sharding) is a
   deferred extension, not part of this version.
 

--- a/docs/publishing-dedi-files.md
+++ b/docs/publishing-dedi-files.md
@@ -135,7 +135,8 @@ or — for a small registry — embedded verbatim in the manifest's `files[]` (s
     "name": "public-keys",                    // → {registry_name}
     "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/public_key.json",
     "state": "live",                          // live | inactive
-    "updated_at": "2026-07-08T10:00:00Z"      // content last changed, not merely re-issued
+    "updated_at": "2026-07-08T10:00:00Z",     // content last changed, not merely re-issued
+    "meta": { "display_name": "Example Org signing keys" }  // optional free-form metadata
   },
 
   "records": [                                // pure list entries — a name + schema-conformant data
@@ -174,6 +175,11 @@ or — for a small registry — embedded verbatim in the manifest's `files[]` (s
   A DeDi server MUST expose an ingested record at exactly that triple, regardless of which file, host,
   or manifest it was crawled from.
 - **`schema`** is a URL or an inline JSON Schema object, never anchored to a central host.
+- **`meta` is optional and free-form** — an object at the registry level and per record
+  (`records[].meta`), for auxiliary content such as display names, contacts, or references; it
+  mirrors the `meta` field of the DeDi API. It is signed with the rest of the file but carries no
+  verification semantics, and it is not a place for lifecycle or trust data: lifecycle stays at the
+  registry level, and keys and validity stay in the manifest and negative registries.
 - One file = one registry. Splitting a very large registry across multiple files (sharding) is a
   deferred extension, not part of this version.
 

--- a/docs/publishing-dedi-files.md
+++ b/docs/publishing-dedi-files.md
@@ -183,6 +183,7 @@ or — for a small registry — embedded verbatim in the manifest's `files[]` (s
   file but carry no verification semantics, and neither is a place for lifecycle or trust data:
   lifecycle stays at the registry level, and keys and validity stay in the manifest and negative
   registries.
+  The manifest likewise MAY carry a `description` — the namespace-level equivalent.
 - One file = one registry. Splitting a very large registry across multiple files (sharding) is a
   deferred extension, not part of this version.
 
@@ -241,6 +242,7 @@ files. It is signed, and served under the domain's TLS at the well-known path (R
   "type": "dedi-manifest",                    // optional
   "domain": "example.org",                    // self-identifies a relayed copy; verify checks served host == this
   "name": "Example Org Trust Services",       // optional
+  "description": "Trust registries of Example Org",  // optional
 
   "keys": [                                   // ← THE AUTHORITY. current signing key(s); presence = valid.
     { "kid": "key-1", "kty": "OKP", "crv": "Ed25519", "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" }

--- a/examples/dedi.index.json
+++ b/examples/dedi.index.json
@@ -3,6 +3,7 @@
   "type": "dedi-manifest",
   "domain": "example.org",
   "name": "Example Org Trust Services",
+  "description": "Trust registries of Example Org",
   "keys": [
     { "kid": "key-1", "kty": "OKP", "crv": "Ed25519", "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" }
   ],

--- a/examples/dedi.public-keys.json
+++ b/examples/dedi.public-keys.json
@@ -17,7 +17,8 @@
     "name": "public-keys",
     "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/public_key.json",
     "state": "live",
-    "updated_at": "2026-07-08T10:00:00Z"
+    "updated_at": "2026-07-08T10:00:00Z",
+    "meta": { "display_name": "Example Org signing keys", "contact": "trust@example.org" }
   },
   "records": [
     {
@@ -28,7 +29,8 @@
         "keyType": "ed25519",
         "keyFormat": "base64",
         "entity": { "name": "Auth Service", "url": "https://example.org/auth" }
-      }
+      },
+      "meta": { "rotation_policy": "https://example.org/policies/key-rotation" }
     },
     {
       "record_name": "signing-service",

--- a/examples/dedi.public-keys.json
+++ b/examples/dedi.public-keys.json
@@ -18,6 +18,7 @@
     "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/public_key.json",
     "state": "live",
     "updated_at": "2026-07-08T10:00:00Z",
+    "description": "Current signing keys for example.org services",
     "meta": { "display_name": "Example Org signing keys", "contact": "trust@example.org" }
   },
   "records": [

--- a/schemas/dedi-file.schema.json
+++ b/schemas/dedi-file.schema.json
@@ -46,7 +46,8 @@
           "oneOf": [{ "type": "string", "format": "uri" }, { "type": "object" }]
         },
         "state": { "type": "string", "enum": ["live", "inactive"], "description": "Whole-registry lifecycle. 'inactive' retires the directory; treat as not authoritative." },
-        "updated_at": { "type": "string", "format": "date-time", "description": "When the registry's content last actually changed (distinct from a re-issue for freshness)." }
+        "updated_at": { "type": "string", "format": "date-time", "description": "When the registry's content last actually changed (distinct from a re-issue for freshness)." },
+        "meta": { "type": "object", "description": "Optional free-form metadata about the registry. Signed with the rest of the document; carries no verification semantics. Not a place for lifecycle or trust data." }
       }
     },
     "records": {
@@ -58,7 +59,8 @@
         "additionalProperties": false,
         "properties": {
           "record_name": { "type": "string", "description": "Record name; maps to {record_name}. MUST be unique within the registry — duplicates make the file invalid. Case-sensitive; no character-set restriction; percent-encoded when used in a URL path. A record is addressed as {namespace}/{registry_name}/{record_name}." },
-          "details": { "type": "object", "description": "The schema-conformant payload; same field as the DeDi API Record.details." }
+          "details": { "type": "object", "description": "The schema-conformant payload; same field as the DeDi API Record.details." },
+          "meta": { "type": "object", "description": "Optional free-form metadata about the record. Signed with the rest of the document; carries no verification semantics. Not a place for lifecycle or trust data — lifecycle stays at the registry level." }
         }
       }
     },

--- a/schemas/dedi-file.schema.json
+++ b/schemas/dedi-file.schema.json
@@ -47,6 +47,7 @@
         },
         "state": { "type": "string", "enum": ["live", "inactive"], "description": "Whole-registry lifecycle. 'inactive' retires the directory; treat as not authoritative." },
         "updated_at": { "type": "string", "format": "date-time", "description": "When the registry's content last actually changed (distinct from a re-issue for freshness)." },
+        "description": { "type": "string", "description": "Optional human-readable description of the registry. Mirrors the DeDi API's description field." },
         "meta": { "type": "object", "description": "Optional free-form metadata about the registry. Signed with the rest of the document; carries no verification semantics. Not a place for lifecycle or trust data." }
       }
     },
@@ -60,6 +61,7 @@
         "properties": {
           "record_name": { "type": "string", "description": "Record name; maps to {record_name}. MUST be unique within the registry — duplicates make the file invalid. Case-sensitive; no character-set restriction; percent-encoded when used in a URL path. A record is addressed as {namespace}/{registry_name}/{record_name}." },
           "details": { "type": "object", "description": "The schema-conformant payload; same field as the DeDi API Record.details." },
+          "description": { "type": "string", "description": "Optional human-readable description of the record. Mirrors the DeDi API's description field." },
           "meta": { "type": "object", "description": "Optional free-form metadata about the record. Signed with the rest of the document; carries no verification semantics. Not a place for lifecycle or trust data — lifecycle stays at the registry level." }
         }
       }

--- a/schemas/dedi-manifest.schema.json
+++ b/schemas/dedi-manifest.schema.json
@@ -11,6 +11,7 @@
     "type": { "type": "string", "const": "dedi-manifest", "description": "Optional discriminator." },
     "domain": { "type": "string", "description": "The publisher domain. Self-identifies a relayed copy; a verifier checks that the serving host matches this." },
     "name": { "type": "string", "description": "Optional human label." },
+    "description": { "type": "string", "description": "Optional human-readable description of the publisher/namespace. Mirrors the DeDi API's namespace description field." },
     "keys": {
       "type": "array",
       "description": "The publisher's current signing key(s) as RFC 7517 JWKs. Presence in this array = valid. Rotation adds/removes; revocation removes.",


### PR DESCRIPTION
Adds optional `meta` and `description` fields to the DeDi file format, at two levels each:

- **`registry.meta`** / **`registry.description`**
- **`records[].meta`** / **`records[].description`**

`description` is a human-readable string; `meta` is a free-form object. Both are optional, signed with the rest of the document, and carry no verification semantics. `meta` is not a place for lifecycle or trust data: lifecycle stays at the registry level, and keys and validity stay in the manifest and negative registries. Both mirror the DeDi API's fields of the same names, so records round-trip between the API and files without loss.

Before this change `meta` was not merely absent but rejected: both schemas set `additionalProperties: false`, so a file carrying it failed shape-check. `meta` is now the sanctioned extension point; unknown sibling fields remain rejected.

Per review, the manifest also carries an optional **`description`** — the namespace-level equivalent, mirroring the DeDi API's namespace description. `meta` remains deliberately excluded from the manifest: the well-known is fetched by every verifier for the key check and stays minimal, and an inline registry's `meta` already travels inside its embedded file.

## Contents

- `schemas/dedi-file.schema.json` — `meta` and `description` at both levels
- `schemas/dedi-manifest.schema.json` — optional `description` (namespace level)
- `docs/publishing-dedi-files.md` — field note in 5.1; one line in the section 5 example
- `examples/dedi.public-keys.json` — demonstrates both placements; other examples stay meta-free

