### PR TITLE
Make digests optional; add a signed digests file the manifest may point to

### DIFF
--- a/docs/publishing-dedi-files.md
+++ b/docs/publishing-dedi-files.md
@@ -211,6 +211,7 @@ them administrable and gives a single place to scope the HTTP headers below:
 https://example.org/.well-known/dedi.index.json            ← manifest — fixed path, normative (RFC 8615)
 https://example.org/dedi/dedi.public-keys.json       ← files — RECOMMENDED convention
 https://example.org/dedi/dedi.revocations.json
+https://example.org/dedi/dedi.digests.json           ← digests file — optional (6.3)
 ```
 
 Only the manifest's location is normative; RFC 8615 exists precisely to make a small discovery
@@ -253,7 +254,7 @@ files. It is signed, and served under the domain's TLS at the well-known path (R
 
   "files": [                                  // the registries offered — discovery + change-detection
     { "registry": "public-keys", "url": "https://example.org/dedi/dedi.public-keys.json",
-      "digest": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aebae",
+      "digest": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aeba",   // optional — or via a digests file (6.3)
       "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/Public_key.json" },
     { "registry": "revocations", "url": "https://example.org/dedi/dedi.revocations.json",
       "digest": "sha-256:5b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f0",
@@ -286,12 +287,46 @@ manifest tamper-evident once it has been cached or relayed away from the origin.
 There is no separate revocation registry for *keys*: presence in `keys` **is** validity. A publisher
 manages its entire key lifecycle by editing its own well-known.
 
-### 6.3 `files[].digest`
+### 6.3 Digests
 
-The whole-file digest lets the *signed* manifest vouch for each DeDi file before it is fetched, and
-lets a server detect a change (digest moved → re-fetch). It is the only place a whole-file hash is needed;
-the file's own signature secures its internal integrity. An inline entry (6.4) carries no digest:
-the manifest's own signature covers its bytes directly.
+A digest lets a *signed* document other than the file itself vouch for the file's current bytes: a
+verifier knows which version is current before fetching, and a server detects a change without
+fetching (digest moved → re-fetch). The file's own signature secures its internal integrity; a file
+cannot vouch for its own currency. An inline entry (6.4) has no digest: the manifest's signature
+covers its bytes directly.
+
+`files[].digest` is OPTIONAL. A publisher that supplies digests does so in one of two places:
+
+- **In the manifest**, as `files[].digest` — the form shown above.
+- **In a digests file**, referenced from the manifest by the optional `digests` URL. This keeps the
+  manifest stable — it changes only when keys or the registry list change — while the digests file,
+  hosted anywhere the publisher controls (`/dedi/dedi.digests.json` RECOMMENDED), is re-issued on
+  every content change.
+
+```jsonc
+// in the manifest
+"digests": "https://example.org/dedi/dedi.digests.json",   // optional — signed pointer
+
+// /dedi/dedi.digests.json — signed by a key in the manifest's `keys`
+{
+  "dedi_version": "0.1",
+  "type": "dedi-digests",
+  "domain": "example.org",
+  "updated_at": "2026-07-08T10:00:00Z",
+  "next_update": "2026-07-09T10:00:00Z",
+  "digests": {
+    "public-keys": "sha-256:9f2c...",
+    "revocations": "sha-256:5b1a..."
+  },
+  "proof": { "verification_method": "key-1", "canonicalization": "JCS", "jws": "eyJ..." }
+}
+```
+
+The digests file is verified like the manifest: its signature is checked against a key the manifest
+lists. Where a registry's digest appears in both places, the digests file takes precedence. A registry
+with a digest in neither place carries no digest commitment. On a digest mismatch, a verifier
+re-fetches the digests file (or the manifest) before rejecting the file, since its cached copy may
+predate the change.
 
 ### 6.4 Inline registries
 
@@ -549,9 +584,9 @@ sequenceDiagram
     participant S as DeDi server
     P->>P: edit record.details, set registry.updated_at
     P->>P: re-sign file
-    P->>P: update the file's digest in the manifest, re-sign manifest
+    P->>P: update the file's digest (digests file, or manifest), re-sign it
     Note over P,S: no list, no key change
-    S->>P: crawl manifest — digest changed
+    S->>P: crawl digests file / manifest — digest changed
     S->>P: GET the changed DeDi file
     S->>S: verify, re-index
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@ Same publisher (`example.org`) and key (`key-1`) throughout.
 
 | File | What it is |
 |---|---|
-| [`dedi.index.json`](dedi.index.json) | The publisher's `/.well-known/dedi.index.json` manifest — declares the current key, lists two referenced registries, and embeds a third (`trust-anchors`) inline. **The authority.** |
+| [`dedi.index.json`](dedi.index.json) | The publisher's `/.well-known/dedi.index.json` manifest — declares the current key, lists two referenced registries, embeds a third (`trust-anchors`) inline, and points to a digests file. **The authority.** |
+| [`dedi.digests.json`](dedi.digests.json) | The digests file the manifest points to — current digest per registry, signed by the same key, re-issued on every content change so the manifest itself stays stable. |
 | [`dedi.public-keys.json`](dedi.public-keys.json) | A positive directory: presence of a record = a valid key. |
 | [`dedi.revocations.json`](dedi.revocations.json) | A negative list: presence of a record = revoked. Same shape; polarity comes from the registry, not a per-record field. |
 | [`domains.txt`](domains.txt) | The discovery list — publisher domains, one per line, with an optional `# head:` last-changed marker. Vouches for nobody. |
@@ -19,6 +20,7 @@ As hosted, these correspond to the recommended layout:
 https://example.org/.well-known/dedi.index.json          ← manifest — fixed path (RFC 8615)
 https://example.org/dedi/dedi.public-keys.json     ← files — RECOMMENDED convention
 https://example.org/dedi/dedi.revocations.json
+https://example.org/dedi/dedi.digests.json         ← digests file — optional
 ```
 
 The `dedi.*.json` name and the `/dedi/` directory are conventions; nothing in verification or

--- a/examples/dedi.digests.json
+++ b/examples/dedi.digests.json
@@ -1,0 +1,16 @@
+{
+  "dedi_version": "0.1",
+  "type": "dedi-digests",
+  "domain": "example.org",
+  "updated_at": "2026-07-08T10:00:00Z",
+  "next_update": "2026-07-09T10:00:00Z",
+  "digests": {
+    "public-keys": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aeba",
+    "revocations": "sha-256:5b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f0"
+  },
+  "proof": {
+    "verification_method": "key-1",
+    "canonicalization": "JCS",
+    "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..ILLUSTRATIVE_DETACHED_SIGNATURE_NOT_CRYPTOGRAPHICALLY_VALID"
+  }
+}

--- a/examples/dedi.index.json
+++ b/examples/dedi.index.json
@@ -9,17 +9,16 @@
   ],
   "updated_at": "2026-07-01T09:00:00Z",
   "next_update": "2026-07-15T10:00:00Z",
+  "digests": "https://example.org/dedi/dedi.digests.json",
   "files": [
     {
       "registry": "public-keys",
       "url": "https://example.org/dedi/dedi.public-keys.json",
-      "digest": "sha-256:9f2c1d4e7a8b0c3d5e6f70819293a4b5c6d7e8f90a1b2c3d4e5f60718293aeba",
       "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/Public_key.json"
     },
     {
       "registry": "revocations",
       "url": "https://example.org/dedi/dedi.revocations.json",
-      "digest": "sha-256:5b1a2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f0",
       "schema": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/Revoke.json"
     },
     {

--- a/schemas/dedi-digests.schema.json
+++ b/schemas/dedi-digests.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "https://raw.githubusercontent.com/LF-Decentralized-Trust-labs/decentralized-directory-protocol/main/schemas/dedi-digests.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DeDi Digests",
+  "description": "A signed document carrying the current digest of each of a publisher's DeDi files, referenced from the manifest by its digests URL. Lets the manifest stay stable while content changes: the manifest is re-issued only when keys or the registry list change; this document is re-issued on every content update. Signed by a key listed in the manifest's keys; verified like the manifest. Entries take precedence over files[].digest in the manifest. /dedi/dedi.digests.json is the RECOMMENDED location. See docs/publishing-dedi-files.md section 6.3. NOTE: the schema $id points at the mutable main branch and must be pinned to a release tag before release.",
+  "type": "object",
+  "required": ["dedi_version", "type", "domain", "updated_at", "next_update", "digests", "proof"],
+  "additionalProperties": false,
+  "properties": {
+    "dedi_version": { "type": "string" },
+    "type": { "type": "string", "const": "dedi-digests", "description": "Discriminator." },
+    "domain": { "type": "string", "description": "The publisher domain; MUST equal the manifest's domain." },
+    "updated_at": { "type": "string", "format": "date-time", "description": "When any digest last changed." },
+    "next_update": { "type": "string", "format": "date-time", "description": "After this time the document MUST be treated as stale and re-fetched." },
+    "digests": { "type": "object", "description": "Registry name → digest of that registry's current DeDi file, prefixed with the algorithm, e.g. 'sha-256:...'. A registry absent here has no digest commitment from this document.", "additionalProperties": { "type": "string" }},
+    "proof": {
+      "type": "object",
+      "description": "Detached JWS over the JCS-canonicalized document with this proof block removed, signed by a key listed in the manifest's keys.",
+      "required": ["verification_method", "canonicalization", "jws"],
+      "additionalProperties": false,
+      "properties": {
+        "verification_method": { "type": "string", "description": "MUST reference a kid in the manifest's keys." },
+        "canonicalization": {
+          "type": "string",
+          "enum": ["JCS"]
+        },
+        "jws": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/dedi-manifest.schema.json
+++ b/schemas/dedi-manifest.schema.json
@@ -33,20 +33,21 @@
     },
     "updated_at": { "type": "string", "format": "date-time", "description": "When the keys or file list last actually changed." },
     "next_update": { "type": "string", "format": "date-time", "description": "How long a verifier may cache these keys before re-fetching; also the revocation-propagation bound." },
+    "digests": { "type": "string", "format": "uri", "description": "Optional URL of a signed digests document (schema dedi-digests.json) carrying per-registry digests, so the manifest need not change on every content update. Its entries take precedence over files[].digest." },
     "files": {
       "type": "array",
-      "description": "The DeDi files (registries) this publisher offers. An entry is a reference (the file is hosted at url, committed to by digest) or an inline entry (a complete DeDi file object embedded verbatim), never both. Registry names MUST be unique across entries.",
+      "description": "The DeDi files (registries) this publisher offers. An entry is a reference (the file is hosted at url, optionally committed to by a digest) or an inline entry (a complete DeDi file object embedded verbatim), never both. Registry names MUST be unique across entries.",
       "items": {
         "oneOf": [
           {
             "type": "object",
             "description": "Referenced entry: the DeDi file is hosted at url.",
-            "required": ["registry", "url", "digest"],
+            "required": ["registry", "url"],
             "additionalProperties": false,
             "properties": {
               "registry": { "type": "string", "description": "Registry name." },
               "url": { "type": "string", "format": "uri", "description": "Absolute URL where the DeDi file is hosted; may be any host the publisher controls, including one different from the manifest's own domain. Authoritative for location: filename and directory conventions are never consulted." },
-              "digest": { "type": "string", "description": "Digest of the referenced DeDi file, so this signed manifest commits to its content and changes are detectable. Prefixed algorithm, e.g. 'sha-256:...'." },
+              "digest": { "type": "string", "description": "Optional. Digest of the referenced DeDi file, so this signed manifest commits to its content and changes are detectable. Prefixed algorithm, e.g. 'sha-256:...'. May instead be supplied via the digests document referenced by the manifest's digests URL, which takes precedence." },
               "schema": {
                 "description": "Optional: the registry's schema (URL or inline), echoed for discovery/filtering without fetching the file.",
                 "oneOf": [{ "type": "string", "format": "uri" }, { "type": "object" }]


### PR DESCRIPTION
Adopters report that `/.well-known/` is often a restricted path — hard for developers to update every time a registry's content changes. Today every content change forces a manifest re-issue because `files[].digest` lives there.

## Change

- **`files[].digest` is now optional.**
- **New optional `digests` URL on the manifest**, pointing to a signed **digests document** (`schemas/dedi-digests.schema.json`, recommended at `/dedi/dedi.digests.json`) carrying the current digest per registry. The manifest then changes only on key rotation or registry add/remove; the digests file is re-issued on every content change, from a path developers control.
- **Precedence:** the digests file wins over an inline `files[].digest`; a registry in neither carries no digest commitment.
- **Mismatch handling:** a verifier re-fetches the digests file (or manifest) before rejecting a file, since its cached copy may predate the change.

The digests document is signed and verified exactly like the manifest (JCS + detached JWS, key ∈ manifest `keys`). Inline registries (6.4) are unaffected — they never had a digest.

## Contents

- `docs/publishing-dedi-files.md` — section 6.3 rewritten; 5.2 layout, section 6 example, and workflow A.2 updated. Also fixes a 65-character placeholder digest in the section 6 example.
- `schemas/dedi-manifest.schema.json` — `digest` no longer required; new `digests` property
- `schemas/dedi-digests.schema.json` — new
- `examples/dedi.index.json` now uses the pointer form; `examples/dedi.digests.json` added; README updated

Backward compatible: manifests with inline digests remain valid (verified).